### PR TITLE
videos on show styled a little

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,7 +47,7 @@ h2 {
 p {
   font-family: 'Lato', sans-serif;
   font-weight: normal;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
 }
 
 a {

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -3,6 +3,12 @@
   padding: 1.5rem 1rem 1rem 1rem;
 }
 
+.spot-video {
+  background-color: $sk8it-blue;
+  margin: 1rem;
+  padding: 1.5rem 1rem 1rem 1rem;
+}
+
 h2 {
   margin-left: 1rem;
 }
@@ -57,8 +63,7 @@ i {
 
 .video-infos {
   background: #30475E;
-  padding: 16px;
+  padding: 8px;
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
 }

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -26,20 +26,46 @@
 </div>
 
 
-<div class="btn-upload">
+<div class="btn-upload mb-3">
   <%= link_to "Upload Video", new_spot_video_path(@spot), class: "btn btn-gradient" %>
 </div>
 
-<div class="spot">
-  <h2>Top Video</h2>
-  <% @spot.videos.each do |video| %>
-    <div class="container">
-      <%= cl_video_tag(video.video.key, controls: true, width: 300) %>
-      <div class="video-infos">
-        <p><%= video.caption %><p>
-        <p>Rating: </p>
-      </div>
+<% if @spot.videos.empty? %>
+    <h2>No videos. Be the first to add one!</h2>
+  <% else %>
+    <h2>Top Video</h2>
+    <div class="spot-video">
+      <% videos = @spot.videos %>
+      <% top_video = videos.sort_by(&:votes).last %>
+      <div class="container px-0">
+          <%= cl_video_tag(top_video.video.key, controls: true, width: 335) %>
+          <div class="video-infos">
+            <div class="container d-flex px-0 align-items-center">
+              <%= cl_image_tag current_user.photo.attached? ? cl_image_path(current_user.photo.key) : image_path("https://mobilityoi.org/wp-content/uploads/2015/06/Avatar-No-Photo-generic.jpg"), class: "avatar-bordered ml-2" %>
+              <p class="pl-4 m-0"><%= top_video.user.username %><p>
+            </div>
+            <div>
+              <p>Votes: <%= top_video.votes %></p>
+            </div>
+          </div>
+        </div>
     </div>
-  <% end %>
-</div>
 
+    <h2>Videos</h2>
+    <div class="spot-video">
+      <% @spot.videos.each do |video| %>
+        <div class="container px-0">
+          <%= cl_video_tag(video.video.key, controls: true, width: 335) %>
+          <div class="video-infos">
+            <div class="container d-flex px-0 align-items-center">
+              <%= cl_image_tag current_user.photo.attached? ? cl_image_path(current_user.photo.key) : image_path("https://mobilityoi.org/wp-content/uploads/2015/06/Avatar-No-Photo-generic.jpg"), class: "avatar-bordered ml-2" %>
+              <p class="pl-4 m-0"><%= video.user.username %><p>
+            </div>
+            <div>
+              <p>Votes: <%= video.votes %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+<% end %>


### PR DESCRIPTION
I styled the videos on the show pages a little. The top video properly shows and below that, all videos show(including the top video, haven't worked that out yet). If a spot has no videos,  a message will display instead

![image](https://user-images.githubusercontent.com/77267436/130800662-91e0534b-cca4-4d90-a3d2-ca30a6459b6d.png)
![image](https://user-images.githubusercontent.com/77267436/130800759-1196f5ff-2ed3-401d-b15a-26dbf8f82c76.png)
![image](https://user-images.githubusercontent.com/77267436/130800814-aa015026-241b-4b8a-b93c-dd19fe41b8a4.png)

